### PR TITLE
Fix Storybook indexing by typing story args instead of casting them away

### DIFF
--- a/apps/storybook/components/Avatar/Avatar.stories.tsx
+++ b/apps/storybook/components/Avatar/Avatar.stories.tsx
@@ -15,8 +15,8 @@ const meta = {
     color: { control: 'color' },
     textColor: { control: 'color' },
   },
-  decorators: [(Story: any) => <View style={{ padding: 24, alignItems: 'center' }}><Story /></View>],
-} as unknown as Meta<typeof Avatar>;
+  decorators: [(Story) => <View style={{ padding: 24, alignItems: 'center' }}><Story /></View>],
+} satisfies Meta<typeof Avatar>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/apps/storybook/components/Button/Button.stories.tsx
+++ b/apps/storybook/components/Button/Button.stories.tsx
@@ -19,7 +19,22 @@ const mockOnPress = () => console.log('pressed');
  * `iconPosition`, `color`, `backgroundColor`, and `onPress`.
  */
 
-const meta = {
+/**
+ * `iconName`, `iconLibrary` and `iconSize` are story-only controls rather than
+ * Button props — three flat fields drive the panel better than the nested
+ * `icon` object, and RenderTemplate below reassembles them (leaving `icon`
+ * undefined when no name is given, which is what keeps the default story
+ * icon-free).
+ */
+type ButtonIcon = NonNullable<React.ComponentProps<typeof Button>['icon']>;
+
+type ButtonStoryArgs = React.ComponentProps<typeof Button> & {
+  iconName?: string;
+  iconLibrary?: ButtonIcon['library'];
+  iconSize?: ButtonIcon['size'];
+};
+
+const meta: Meta<ButtonStoryArgs> = {
   title: 'Components/Button',
   component: Button,
   args: {
@@ -58,14 +73,14 @@ const meta = {
       },
     },
   },
-  decorators: [(Story: any) => <View style={styles.container}><Story /></View>],
-} as unknown as Meta<typeof Button>;
+  decorators: [(Story) => <View style={styles.container}><Story /></View>],
+};
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<ButtonStoryArgs>;
 
-const RenderTemplate = (args: any) => {
+const RenderTemplate = (args: ButtonStoryArgs) => {
   const { iconName, iconLibrary, iconSize, ...rest } = args;
 
   const icon = iconName ? { name: iconName, library: iconLibrary || 'Feather', size: iconSize || 18 } : undefined;

--- a/apps/storybook/components/Chip/Chip.stories.tsx
+++ b/apps/storybook/components/Chip/Chip.stories.tsx
@@ -23,8 +23,8 @@ const meta = {
     onPress: { action: 'pressed' },
     onIconPress: { action: 'icon pressed' },
   },
-  decorators: [(Story: any) => <View style={styles.container}><Story /></View>],
-} as unknown as Meta<typeof Chip>;
+  decorators: [(Story) => <View style={styles.container}><Story /></View>],
+} satisfies Meta<typeof Chip>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/apps/storybook/components/Collapsible/Collapsible.stories.tsx
+++ b/apps/storybook/components/Collapsible/Collapsible.stories.tsx
@@ -16,7 +16,12 @@ import { Collapsible, Typography } from '@nativectx/ui';
  * `contentVariant`, `iconLibrary`, `iconName`.
  */
 
-const meta = {
+type CollapsibleStoryArgs = React.ComponentProps<typeof Collapsible>;
+
+// Explicit args generic rather than `typeof meta`: these stories drive the
+// component from inside `render` instead of through args, so inferring
+// required args from meta would demand args the stories never use.
+const meta: Meta<CollapsibleStoryArgs> = {
   title: 'Components/Collapsible',
   component: Collapsible,
   args: {
@@ -51,12 +56,12 @@ const meta = {
       },
     },
   },
-  decorators: [(Story: any) => <View style={styles.container}><Story /></View>],
-} as unknown as Meta<typeof Collapsible>;
+  decorators: [(Story) => <View style={styles.container}><Story /></View>],
+};
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<CollapsibleStoryArgs>;
 
 export const Playground: Story = {
   render: (args) => (

--- a/apps/storybook/components/Divider/Divider.stories.tsx
+++ b/apps/storybook/components/Divider/Divider.stories.tsx
@@ -15,8 +15,8 @@ const meta = {
     inset: { control: 'select', options: ['none', 'start', 'middle'] },
     color: { control: 'color' },
   },
-  decorators: [(Story: any) => <View style={{ padding: 24, width: '100%' }}><Story /></View>],
-} as unknown as Meta<typeof Divider>;
+  decorators: [(Story) => <View style={{ padding: 24, width: '100%' }}><Story /></View>],
+} satisfies Meta<typeof Divider>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/apps/storybook/components/FAB/FAB.stories.tsx
+++ b/apps/storybook/components/FAB/FAB.stories.tsx
@@ -13,7 +13,22 @@ const mockOnPress = () => console.log('FAB pressed');
  * Extended: pass a `label` prop for an extended FAB with icon + text
  */
 
-const meta = {
+/**
+ * `iconName` and `iconLibrary` are story-only controls rather than FAB props:
+ * two flat text fields are far easier to drive from the Storybook panel than
+ * the nested `icon` object, so RenderTemplate below reassembles them. Declaring
+ * them here is what keeps that honest — the `as unknown as Meta<typeof FAB>`
+ * cast this replaces silenced the mismatch, and as a side effect stopped
+ * Storybook's indexer from being able to read the file at all.
+ */
+type FABStoryArgs = React.ComponentProps<typeof FAB> & {
+  iconName?: string;
+  // Derived from the prop rather than widened to `string`, so the control only
+  // offers library names the icon renderer actually knows.
+  iconLibrary?: NonNullable<React.ComponentProps<typeof FAB>['icon']>['library'];
+};
+
+const meta: Meta<FABStoryArgs> = {
   title: 'Components/FAB',
   component: FAB,
   args: {
@@ -41,14 +56,14 @@ const meta = {
     label: { control: 'text', description: 'Label for extended FAB' },
     onPress: { action: 'pressed' },
   },
-  decorators: [(Story: any) => <View style={styles.container}><Story /></View>],
-} as unknown as Meta<typeof FAB>;
+  decorators: [(Story) => <View style={styles.container}><Story /></View>],
+};
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<FABStoryArgs>;
 
-const RenderTemplate = (args: any) => {
+const RenderTemplate = (args: FABStoryArgs) => {
   const { iconName, iconLibrary, label, ...rest } = args;
   const icon = { name: iconName || 'plus', library: iconLibrary || 'Feather' };
   return <FAB {...rest} icon={icon} label={label || undefined} onPress={mockOnPress} />;

--- a/apps/storybook/components/IconButton/IconButton.stories.tsx
+++ b/apps/storybook/components/IconButton/IconButton.stories.tsx
@@ -5,7 +5,17 @@ import { IconButton, IconButtonVariants } from '@nativectx/ui';
 
 const mockOnPress = () => console.log('pressed');
 
-const meta = {
+/**
+ * `iconName` and `iconLibrary` are story-only controls rather than IconButton
+ * props — a flat text field drives the panel better than the nested `icon`
+ * object, and RenderTemplate below reassembles them.
+ */
+type IconButtonStoryArgs = React.ComponentProps<typeof IconButton> & {
+  iconName?: string;
+  iconLibrary?: NonNullable<React.ComponentProps<typeof IconButton>['icon']>['library'];
+};
+
+const meta: Meta<IconButtonStoryArgs> = {
   title: 'Components/IconButton',
   component: IconButton,
   args: {
@@ -29,19 +39,19 @@ const meta = {
     iconLibrary: { control: 'text' },
     onPress: { action: 'pressed' },
   },
-  decorators: [(Story: any) => <View style={styles.container}><Story /></View>],
-} as unknown as Meta<typeof IconButton>;
+  decorators: [(Story) => <View style={styles.container}><Story /></View>],
+};
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<IconButtonStoryArgs>;
 
-const RenderTemplate = (args: any) => {
+const RenderTemplate = (args: IconButtonStoryArgs) => {
   const { iconName, iconLibrary, ...rest } = args;
   return (
     <IconButton
       {...rest}
-      icon={{ name: iconName, library: iconLibrary || 'Feather' }}
+      icon={{ name: iconName || 'heart', library: iconLibrary || 'Feather' }}
       onPress={mockOnPress}
     />
   );

--- a/apps/storybook/components/List/List.stories.tsx
+++ b/apps/storybook/components/List/List.stories.tsx
@@ -15,8 +15,8 @@ const meta = {
     selected: { control: 'boolean' },
     disabled: { control: 'boolean' },
   },
-  decorators: [(Story: any) => <View style={{ padding: 0, width: '100%' }}><Story /></View>],
-} as unknown as Meta<typeof ListItem>;
+  decorators: [(Story) => <View style={{ padding: 0, width: '100%' }}><Story /></View>],
+} satisfies Meta<typeof ListItem>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/apps/storybook/components/Modal/Modal.stories.tsx
+++ b/apps/storybook/components/Modal/Modal.stories.tsx
@@ -3,7 +3,12 @@ import React, { useState } from 'react';
 import { View } from 'react-native';
 import { Modal, Button, Typography } from '@nativectx/ui';
 
-const meta = {
+type ModalStoryArgs = React.ComponentProps<typeof Modal>;
+
+// Explicit args generic rather than `typeof meta`: these stories drive the
+// component from inside `render` instead of through args, so inferring
+// required args from meta would demand args the stories never use.
+const meta: Meta<ModalStoryArgs> = {
   title: 'Components/Modal',
   component: Modal,
   args: {
@@ -13,11 +18,11 @@ const meta = {
   argTypes: {
     dismissable: { control: 'boolean' },
   },
-  decorators: [(Story: any) => <View style={{ padding: 24, alignItems: 'center' }}><Story /></View>],
-} as unknown as Meta<typeof Modal>;
+  decorators: [(Story) => <View style={{ padding: 24, alignItems: 'center' }}><Story /></View>],
+};
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<ModalStoryArgs>;
 
 export const Playground: Story = {
   render: (args) => {

--- a/apps/storybook/components/ProgressIndicator/ProgressIndicator.stories.tsx
+++ b/apps/storybook/components/ProgressIndicator/ProgressIndicator.stories.tsx
@@ -16,8 +16,8 @@ const meta = {
     color: { control: 'color' },
     trackColor: { control: 'color' },
   },
-  decorators: [(Story: any) => <View style={{ padding: 24, gap: 16 }}><Story /></View>],
-} as unknown as Meta<typeof ProgressIndicator>;
+  decorators: [(Story) => <View style={{ padding: 24, gap: 16 }}><Story /></View>],
+} satisfies Meta<typeof ProgressIndicator>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/apps/storybook/components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/apps/storybook/components/SegmentedControl/SegmentedControl.stories.tsx
@@ -14,7 +14,12 @@ const OPTIONS_THREE = [
   { value: 'month', label: 'Month' },
 ];
 
-const meta = {
+type SegmentedControlStoryArgs = React.ComponentProps<typeof SegmentedControl>;
+
+// Explicit args generic rather than `typeof meta`: these stories drive the
+// component from inside `render` instead of through args, so inferring
+// required args from meta would demand args the stories never use.
+const meta: Meta<SegmentedControlStoryArgs> = {
   title: 'Components/SegmentedControl',
   component: SegmentedControl,
   args: {
@@ -26,11 +31,11 @@ const meta = {
     disabled: { control: 'boolean' },
     onChange: { action: 'changed' },
   },
-  decorators: [(Story: any) => <View style={styles.container}><Story /></View>],
-} as unknown as Meta<typeof SegmentedControl>;
+  decorators: [(Story) => <View style={styles.container}><Story /></View>],
+};
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<SegmentedControlStoryArgs>;
 
 export const Playground: Story = {};
 

--- a/apps/storybook/components/Slider/Slider.stories.tsx
+++ b/apps/storybook/components/Slider/Slider.stories.tsx
@@ -22,8 +22,8 @@ const meta = {
     onValueChange: { action: 'value changed' },
     onSlidingComplete: { action: 'sliding complete' },
   },
-  decorators: [(Story: any) => <View style={styles.container}><Story /></View>],
-} as unknown as Meta<typeof Slider>;
+  decorators: [(Story) => <View style={styles.container}><Story /></View>],
+} satisfies Meta<typeof Slider>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/apps/storybook/components/Switch/Switch.stories.tsx
+++ b/apps/storybook/components/Switch/Switch.stories.tsx
@@ -17,8 +17,8 @@ const meta = {
     label: { control: 'text' },
     onValueChange: { action: 'changed' },
   },
-  decorators: [(Story: any) => <View style={styles.container}><Story /></View>],
-} as unknown as Meta<typeof Switch>;
+  decorators: [(Story) => <View style={styles.container}><Story /></View>],
+} satisfies Meta<typeof Switch>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/apps/storybook/components/TextInput/TextInput.stories.tsx
+++ b/apps/storybook/components/TextInput/TextInput.stories.tsx
@@ -15,8 +15,8 @@ const meta = {
     variant: { control: 'select', options: ['filled', 'outlined'] },
     disabled: { control: 'boolean' },
   },
-  decorators: [(Story: any) => <View style={{ padding: 24, gap: 16 }}><Story /></View>],
-} as unknown as Meta<typeof ThemedTextInput>;
+  decorators: [(Story) => <View style={{ padding: 24, gap: 16 }}><Story /></View>],
+} satisfies Meta<typeof ThemedTextInput>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/apps/storybook/components/ThemedImage/ThemedImage.stories.tsx
+++ b/apps/storybook/components/ThemedImage/ThemedImage.stories.tsx
@@ -18,8 +18,8 @@ const meta = {
       options: ['contain', 'cover', 'fill', 'none', 'scale-down'],
     },
   },
-  decorators: [(Story: any) => <View style={styles.container}><Story /></View>],
-} as unknown as Meta<typeof ThemedImage>;
+  decorators: [(Story) => <View style={styles.container}><Story /></View>],
+} satisfies Meta<typeof ThemedImage>;
 
 export default meta;
 

--- a/apps/storybook/components/ThemedView/ThemedView.stories.tsx
+++ b/apps/storybook/components/ThemedView/ThemedView.stories.tsx
@@ -23,8 +23,8 @@ const meta = {
       description: 'M3 elevation level (0–5). Card variant defaults to 1.',
     },
   },
-  decorators: [(Story: any) => <View style={styles.container}><Story /></View>],
-} as unknown as Meta<typeof ThemedView>;
+  decorators: [(Story) => <View style={styles.container}><Story /></View>],
+} satisfies Meta<typeof ThemedView>;
 
 export default meta;
 


### PR DESCRIPTION
`pnpm dev:storybook` has been failing to start. Storybook rejected **16 of 17** story files with `CSF: default export must be an object` and exited with a broken build. This fixes it.

## Root cause

A double cast. Every failing file ended its meta with `} as unknown as Meta<typeof X>`. Storybook's indexer resolves `export default meta` back to its declaration by unwrapping **one** type expression; `as unknown as` is two nested ones, so it gave up and reported the object as not-an-object.

The diagnosis was a natural experiment rather than a guess — the correlation is exact:

| pattern | files | indexes? |
|---|---|---|
| `} as unknown as Meta<typeof X>;` | 16 | ❌ all fail |
| `} satisfies Meta<typeof Typography>;` | 1 | ✅ works |

`Typography.stories.tsx` is the one file that never had the cast, and the one file that always worked.

## What the cast had been hiding

`as unknown as` suppresses type checking outright, so removing it type-checked these objects for the first time. 28 errors surfaced, in two real classes:

**1. Undeclared story args (Button, FAB, IconButton).** These declare `iconName`/`iconLibrary`/`iconSize` args that aren't props of any of those components. They are *not* dead code — a `RenderTemplate` in each file reassembles them into the nested `icon` object, because flat text fields drive the controls panel far better than a nested one. They're now declared in a story-args type instead of smuggled past the compiler, and `iconLibrary` is **derived from the prop** rather than widened to `string`, so the control can only offer libraries the icon renderer actually knows.

`IconButton` also gained the `iconName` fallback `FAB` already had — without it the required `IconConfig.name` could be `undefined`.

**2. Render-driven stories (Collapsible, Modal, SegmentedControl).** These drive their components from inside `render` rather than through args, so `StoryObj<typeof meta>` demanded args the stories never use. They take an explicit args generic instead.

No component/library types were changed — this is entirely `apps/storybook/`.

## Verification

Verified by **booting Storybook**, not just compiling — which matters, because CI never runs Storybook and that's exactly how this rotted unnoticed:

- serves HTTP 200
- **0** indexing errors
- `/index.json` lists **92 entries across all 17 components**
- `pnpm verify` green (109 tests), `tsc --noEmit` clean in `apps/storybook`

## Deliberately not included

The `"storybook": "10.2.10"` override stays. That exact pin exists only to dodge 10.5.x's stricter indexer, and this fix **does** clear it — I confirmed 10.5.6 indexes all 92 entries. But the only route to move within the caret, `pnpm update -r storybook`, rewrote the lockfile such that `minimatch` lost `brace-expansion` and eslint could no longer start. Relaxing that pin deserves its own change and its own verification rather than riding along here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)