### PR TITLE
Follow the OS light/dark setting in NativeCtxProvider

### DIFF
--- a/.claude/skills/nativectx-theme.md
+++ b/.claude/skills/nativectx-theme.md
@@ -77,8 +77,30 @@ input.background, input.border, input.focusBorder, input.errorColor
 ### useThemeMode()
 
 ```tsx
-const { mode, toggleTheme } = useThemeMode();
-// mode: 'light' | 'dark'
+const { mode, setMode, toggleTheme, isFollowingSystem } = useThemeMode();
+// mode: 'light' | 'dark' — always the resolved mode, never 'system'
+// isFollowingSystem: true while mode tracks the OS setting
+```
+
+`NativeCtxProvider` follows the OS light/dark setting out of the box and re-renders
+when the user flips it. `setMode('light' | 'dark')` and `toggleTheme()` are sticky
+user overrides that survive later system changes; `setMode('system')` clears the
+override and resumes following. `toggleTheme()` flips relative to the mode on screen,
+so the first toggle on a dark device goes to light.
+
+Pass `defaultMode` to start pinned instead of following (`'system'` is the default):
+
+```tsx
+<NativeCtxProvider brand={brand} defaultMode="light">
+  <Stack />
+</NativeCtxProvider>
+```
+
+For a three-way Light/Dark/System setting, derive the selection from both fields:
+
+```tsx
+const { mode, setMode, isFollowingSystem } = useThemeMode();
+const selected = isFollowingSystem ? 'system' : mode;
 ```
 
 ---

--- a/apps/demo/src/app/explore/theming.tsx
+++ b/apps/demo/src/app/explore/theming.tsx
@@ -154,11 +154,11 @@ export default function ThemingPage() {
 
       <DemoSection
         title="Dark mode"
-        description="Dark theme is generated automatically from the same seed. Toggle at runtime using useThemeMode()."
+        description="Dark theme is generated automatically from the same seed. The provider follows the OS setting by default; useThemeMode() overrides it at runtime."
       >
         <CodeBlock
           variant="code"
-          code={"import { useThemeMode } from '@nativectx/ui';\n\nconst { mode, toggleTheme } = useThemeMode();\n// mode: 'light' | 'dark'"}
+          code={"import { useThemeMode } from '@nativectx/ui';\n\nconst { mode, setMode, toggleTheme, isFollowingSystem } = useThemeMode();\n// mode: 'light' | 'dark' — resolved, never 'system'\n\nsetMode('dark');    // sticky override, survives system changes\nsetMode('system');  // back to following the OS"}
         />
       </DemoSection>
 

--- a/apps/storybook/.storybook/decorators.tsx
+++ b/apps/storybook/.storybook/decorators.tsx
@@ -25,8 +25,11 @@ const ThemeWrapper = ({
   const themeContextValue = useMemo<ThemeContextType>(() => ({
     values: themeValues,
     mode,
-    setMode,
+    // Storybook drives the mode from its own toolbar global, so 'system' is
+    // treated as a no-op here rather than deferring to the OS.
+    setMode: (m) => { if (m !== 'system') setMode(m); },
     toggleTheme: () => setMode((m) => (m === 'light' ? 'dark' : 'light')),
+    isFollowingSystem: false,
   }), [themeValues, mode]);
 
   return (

--- a/ui/theme/theme.test.tsx
+++ b/ui/theme/theme.test.tsx
@@ -1,18 +1,56 @@
 import React from 'react';
-import { fireEvent, render, renderHook } from '@testing-library/react-native';
+import { act, fireEvent, render, renderHook } from '@testing-library/react-native';
 import { Text, View } from 'react-native';
 import { NativeCtxProvider, useThemeContext, useTheme, useTokens } from './theme';
 import { defaultBrand } from '../brand/default-brand';
 import { createLightTheme, createDarkTheme } from './theme-config';
 
+// `useColorScheme` reads the OS setting through this module, and the native
+// Appearance module it wraps is absent under jest, so the real hook would always
+// report null. Replace it with the same shape — a subscribable store — so that
+// flipping the system theme re-renders subscribers exactly as the device does.
+jest.mock('react-native/Libraries/Utilities/useColorScheme', () => {
+  const { useSyncExternalStore } = require('react');
+  const listeners = new Set<() => void>();
+  let scheme: 'light' | 'dark' | null = 'light';
+
+  const useColorSchemeMock = () =>
+    useSyncExternalStore(
+      (onChange: () => void) => {
+        listeners.add(onChange);
+        return () => listeners.delete(onChange);
+      },
+      () => scheme,
+    );
+  useColorSchemeMock.set = (next: 'light' | 'dark' | null) => {
+    scheme = next;
+    listeners.forEach((notify) => notify());
+  };
+
+  return { __esModule: true, default: useColorSchemeMock };
+});
+
+const colorSchemeStore = jest.requireMock('react-native/Libraries/Utilities/useColorScheme')
+  .default as { set: (next: 'light' | 'dark' | null) => void };
+
+/** Flip the OS setting; mounted providers re-render on their own from here. */
+const setSystemColorScheme = (scheme: 'light' | 'dark' | null) => {
+  act(() => colorSchemeStore.set(scheme));
+};
+
+beforeEach(() => {
+  colorSchemeStore.set('light');
+});
+
 // Test component that exposes theme values for assertions
 const ThemeTestComponent = () => {
-  const { values, mode, toggleTheme, setMode } = useThemeContext();
+  const { values, mode, toggleTheme, setMode, isFollowingSystem } = useThemeContext();
 
   return (
     <View>
       <Text testID="isDark">{String(values.isDark)}</Text>
       <Text testID="mode">{mode}</Text>
+      <Text testID="isFollowingSystem">{String(isFollowingSystem)}</Text>
       <Text testID="primary">{values.primary}</Text>
       <Text testID="surface">{values.surface}</Text>
       <Text testID="onSurface">{values.onSurface}</Text>
@@ -23,6 +61,7 @@ const ThemeTestComponent = () => {
       <Text onPress={toggleTheme} testID="toggleTheme">Toggle</Text>
       <Text onPress={() => setMode('dark')} testID="setDark">Set Dark</Text>
       <Text onPress={() => setMode('light')} testID="setLight">Set Light</Text>
+      <Text onPress={() => setMode('system')} testID="setSystem">Follow System</Text>
     </View>
   );
 };
@@ -105,6 +144,119 @@ describe('NativeCtxProvider Provider', () => {
 
       // Set back to light directly
       fireEvent.press(getByTestId('setLight'));
+      expect(getByTestId('mode').props.children).toBe('light');
+    });
+  });
+
+  describe('System Theme', () => {
+    it('seeds the mode from a system set to dark', () => {
+      colorSchemeStore.set('dark');
+
+      const { getByTestId } = render(
+        <NativeCtxProvider brand={defaultBrand}>
+          <ThemeTestComponent />
+        </NativeCtxProvider>
+      );
+
+      expect(getByTestId('mode').props.children).toBe('dark');
+      expect(getByTestId('isDark').props.children).toBe('true');
+      expect(getByTestId('isFollowingSystem').props.children).toBe('true');
+    });
+
+    it('treats an unknown system color scheme as light', () => {
+      colorSchemeStore.set(null);
+
+      const { getByTestId } = render(
+        <NativeCtxProvider brand={defaultBrand}>
+          <ThemeTestComponent />
+        </NativeCtxProvider>
+      );
+
+      expect(getByTestId('mode').props.children).toBe('light');
+      expect(getByTestId('isFollowingSystem').props.children).toBe('true');
+    });
+
+    it('follows a system theme change with no user action', () => {
+      const { getByTestId } = render(
+        <NativeCtxProvider brand={defaultBrand}>
+          <ThemeTestComponent />
+        </NativeCtxProvider>
+      );
+
+      expect(getByTestId('mode').props.children).toBe('light');
+
+      setSystemColorScheme('dark');
+
+      expect(getByTestId('mode').props.children).toBe('dark');
+      expect(getByTestId('isDark').props.children).toBe('true');
+    });
+
+    it('keeps a setMode override when the system theme changes', () => {
+      const { getByTestId } = render(
+        <NativeCtxProvider brand={defaultBrand}>
+          <ThemeTestComponent />
+        </NativeCtxProvider>
+      );
+
+      fireEvent.press(getByTestId('setLight'));
+      expect(getByTestId('isFollowingSystem').props.children).toBe('false');
+
+      setSystemColorScheme('dark');
+
+      // The user's choice wins over the OS.
+      expect(getByTestId('mode').props.children).toBe('light');
+      expect(getByTestId('isFollowingSystem').props.children).toBe('false');
+    });
+
+    it('resumes following the system after setMode("system")', () => {
+      colorSchemeStore.set('dark');
+
+      const { getByTestId } = render(
+        <NativeCtxProvider brand={defaultBrand}>
+          <ThemeTestComponent />
+        </NativeCtxProvider>
+      );
+
+      fireEvent.press(getByTestId('setLight'));
+      expect(getByTestId('mode').props.children).toBe('light');
+
+      fireEvent.press(getByTestId('setSystem'));
+      expect(getByTestId('mode').props.children).toBe('dark');
+      expect(getByTestId('isFollowingSystem').props.children).toBe('true');
+
+      setSystemColorScheme('light');
+      expect(getByTestId('mode').props.children).toBe('light');
+    });
+
+    it('toggles to light from a system default of dark', () => {
+      colorSchemeStore.set('dark');
+
+      const { getByTestId } = render(
+        <NativeCtxProvider brand={defaultBrand}>
+          <ThemeTestComponent />
+        </NativeCtxProvider>
+      );
+
+      fireEvent.press(getByTestId('toggleTheme'));
+
+      expect(getByTestId('mode').props.children).toBe('light');
+      expect(getByTestId('isFollowingSystem').props.children).toBe('false');
+    });
+
+    it('pins the mode and ignores the system when defaultMode is set', () => {
+      colorSchemeStore.set('dark');
+
+      const { getByTestId } = render(
+        <NativeCtxProvider brand={defaultBrand} defaultMode="light">
+          <ThemeTestComponent />
+        </NativeCtxProvider>
+      );
+
+      expect(getByTestId('mode').props.children).toBe('light');
+      expect(getByTestId('isFollowingSystem').props.children).toBe('false');
+
+      setSystemColorScheme('light');
+      setSystemColorScheme('dark');
       expect(getByTestId('mode').props.children).toBe('light');
     });
   });
@@ -199,6 +351,7 @@ describe('useThemeContext hook', () => {
     expect(result.current).toHaveProperty('mode');
     expect(result.current).toHaveProperty('setMode');
     expect(result.current).toHaveProperty('toggleTheme');
+    expect(result.current).toHaveProperty('isFollowingSystem');
   });
 
   it('throws error when used outside provider', () => {

--- a/ui/theme/theme.tsx
+++ b/ui/theme/theme.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useState, useMemo, useContext } from 'react';
+import { useColorScheme } from 'react-native';
 import { createDarkTheme, createLightTheme, ThemeValuesType, type ThemeTokens } from './theme-config';
 import { Brand } from '../brand';
 import { BrandProvider } from '../brand/brand-context';
@@ -10,9 +11,13 @@ export type ThemeMode = 'light' | 'dark';
 
 export type ThemeContextType = {
   values: ThemeValuesType;
+  /** The resolved mode actually being rendered — never `'system'`. */
   mode: ThemeMode;
-  setMode: (m: ThemeMode) => void;
+  /** Pass `'system'` to clear a user override and resume following the OS. */
+  setMode: (m: ThemeMode | 'system') => void;
   toggleTheme: () => void;
+  /** True while the mode tracks the OS setting; false once the user overrides it. */
+  isFollowingSystem: boolean;
 };
 
 // Sentinel value to detect missing provider
@@ -38,26 +43,44 @@ type NativeCtxProviderProps = {
    * @default 0
    */
   ssrHeight?: number;
+  /**
+   * Theme mode the app starts in.
+   * `'system'` follows the OS light/dark setting and keeps following it until
+   * `setMode` or `toggleTheme` is called; `'light'` or `'dark'` pins the theme
+   * and ignores the OS. Call `setMode('system')` to resume following.
+   * @default 'system'
+   */
+  defaultMode?: ThemeMode | 'system';
 };
 //Initialize NativeCtxProvider with a toggle function
-const NativeCtxProvider = ({ brand, children, ssrWidth, ssrHeight }: NativeCtxProviderProps) => {
+const NativeCtxProvider = ({ brand, children, ssrWidth, ssrHeight, defaultMode = 'system' }: NativeCtxProviderProps) => {
   const lightTheme = useMemo(() => createLightTheme(brand), [brand]);
   // Use brand.darkColors if available, otherwise generate from brand.colors
   const darkTheme = useMemo(() => createDarkTheme(brand), [brand]);
-  const [mode, setModeState] = useState<ThemeMode>('light');
+  // null = follow the OS. An explicit setMode/toggleTheme call parks a mode here
+  // and it wins over the system from then on, until setMode('system') clears it.
+  const [override, setOverride] = useState<ThemeMode | null>(defaultMode === 'system' ? null : defaultMode);
+  // null when the OS preference is unknown (SSR, or web before hydration) —
+  // treat that as light so server output stays deterministic.
+  const systemMode: ThemeMode = useColorScheme() === 'dark' ? 'dark' : 'light';
+  // Derived during render, not synced in an effect: a system change re-renders
+  // with the new theme immediately instead of one frame late.
+  const mode = override ?? systemMode;
   const values = mode === 'light' ? lightTheme : darkTheme;
 
-  const setMode = (m: ThemeMode) => {
-    setModeState(m);
+  const setMode = (m: ThemeMode | 'system') => {
+    setOverride(m === 'system' ? null : m);
   };
 
   const toggleTheme = () => {
-    setModeState((prev) => (prev === 'light' ? 'dark' : 'light'));
+    // Flips relative to the resolved mode, so the first toggle on a dark device
+    // goes to light rather than back to the theme already on screen.
+    setOverride(mode === 'light' ? 'dark' : 'light');
   };
 
   return (
     <BrandProvider brand={brand}>
-      <ThemeContext.Provider value={{ values, mode, setMode, toggleTheme }}>
+      <ThemeContext.Provider value={{ values, mode, setMode, toggleTheme, isFollowingSystem: override === null }}>
         <LayoutProvider ssrWidth={ssrWidth} ssrHeight={ssrHeight}>
           <SidebarProvider>
               {children}
@@ -99,7 +122,11 @@ export const useTheme = (): ThemeValuesType => {
  * Hook to access the current theme mode and controllers.
  * Must be used within a `<NativeCtxProvider>` provider.
  *
- * @returns The theme mode context containing mode, setMode, and toggleTheme
+ * `mode` is always the resolved `'light' | 'dark'`. By default it follows the OS
+ * setting; `setMode('light' | 'dark')` and `toggleTheme()` override that until
+ * `setMode('system')` resumes following. `isFollowingSystem` says which is in effect.
+ *
+ * @returns The theme mode context containing mode, setMode, toggleTheme, and isFollowingSystem
  * @throws Error if used outside of a NativeCtxProvider
  *
  * @example
@@ -109,10 +136,26 @@ export const useTheme = (): ThemeValuesType => {
  *   return <Button title={`Switch to ${mode === 'light' ? 'dark' : 'light'}`} onPress={toggleTheme} />;
  * }
  * ```
+ *
+ * @example
+ * ```tsx
+ * function ThemeSetting() {
+ *   const { mode, setMode, isFollowingSystem } = useThemeMode();
+ *   const selected = isFollowingSystem ? 'system' : mode;
+ *
+ *   return (
+ *     <>
+ *       <Button title="Light" variant={selected === 'light' ? 'filled' : 'outlined'} onPress={() => setMode('light')} />
+ *       <Button title="Dark" variant={selected === 'dark' ? 'filled' : 'outlined'} onPress={() => setMode('dark')} />
+ *       <Button title="System" variant={selected === 'system' ? 'filled' : 'outlined'} onPress={() => setMode('system')} />
+ *     </>
+ *   );
+ * }
+ * ```
  */
 export const useThemeMode = () => {
-  const { mode, setMode, toggleTheme } = useThemeContext();
-  return { mode, setMode, toggleTheme };
+  const { mode, setMode, toggleTheme, isFollowingSystem } = useThemeContext();
+  return { mode, setMode, toggleTheme, isFollowingSystem };
 };
 
 export const useThemeContext = (): ThemeContextType => {


### PR DESCRIPTION
## Problem

`NativeCtxProvider` held its mode in `useState<ThemeMode>('light')` and only ever changed it via `setMode`/`toggleTheme`. Nothing in `ui/` or `apps/demo` imported `useColorScheme` or `Appearance`, so apps built on the library started in light mode on a device set to dark, and never reacted when the user flipped the system theme.

## Approach

Mode is now **derived during render** from an override that defaults to `null` (follow the OS), rather than stored outright — so a system change repaints immediately instead of a frame late, with no effect-syncing:

```ts
const [override, setOverride] = useState<ThemeMode | null>(defaultMode === 'system' ? null : defaultMode);
const systemMode: ThemeMode = useColorScheme() === 'dark' ? 'dark' : 'light';
const mode = override ?? systemMode;
```

An explicit `setMode`/`toggleTheme` call parks a mode in the override and wins from then on; `setMode('system')` clears it and resumes following.

## API changes — all additive

- New `defaultMode?: 'light' | 'dark' | 'system'` prop, defaulting to `'system'`
- `setMode` widened to accept `'system'`; existing `setMode('light' | 'dark')` calls are unchanged
- `toggleTheme()` flips relative to the *resolved* mode, so the first toggle on a dark device goes to light rather than back to what is already on screen
- New `isFollowingSystem` on the context and `useThemeMode()`, for a three-way Light/Dark/System control
- `useColorScheme()` returning `null` (SSR, or web before hydration) maps to light, keeping server output deterministic alongside the existing `ssrWidth`/`ssrHeight` support

`ThemeMode` stays `'light' | 'dark'` and `mode` stays the resolved value, so consumers of the published package are unaffected.

## Notes

- `apps/storybook/.storybook/decorators.tsx` hand-builds a `ThemeContextType`, so it needed the two new members to pass `typecheck:packages`. Storybook drives mode from its toolbar global, so `'system'` is a no-op there.
- **Not included:** persistence of the override across launches (needs a storage dependency), and the demo landing-page hero toggle stays two-state — it is a marketing CTA, not a settings surface. It still improves automatically: on a dark device it now starts dark and reads "Light mode".
- `defaultMode` is read once at mount, matching how `ssrWidth`/`ssrHeight` already behave.

## Verification

`pnpm verify` passes end to end — build, check (8 skill files / 29 components in sync, 17 examples compile), lint at `--max-warnings 0`, typecheck, and **116/116 tests**.

Seven new tests under `NativeCtxProvider Provider > System Theme` cover: seeding from a dark system, unknown scheme treated as light, following a live system change, an override surviving a system change, resuming via `setMode('system')`, toggling to light from a dark system default, and `defaultMode` pinning past the system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)